### PR TITLE
Fix: correct terminology to snake case

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ preset that isn't presented in the show cases, make an issue!
 ### Sub words only
 ```lua
 -- Ignore anything except sub words!
-local CamelCase = "sneak_UPPER_MIXEDCase" .. "1234"
+local CamelCase = "snake_UPPER_MIXEDCase" .. "1234"
 --    ^    ^       ^     ^     ^    ^         ^
 ```
 <details><summary>Configuration</summary>
@@ -36,7 +36,7 @@ local neowords = require("neowords")
 local p = neowords.pattern_presets
 
 local subword_hops = neowords.get_word_hops(
-  p.sneak_case,
+  p.snake_case,
   p.camel_case,
   p.upper_case,
   p.number,
@@ -56,7 +56,7 @@ vim.keymap.set({ "n", "x", "o" }, "ge", subword_hops.backward_end)
 ### Big words only
 ```lua
 -- Ignore anything except big words!
-local CamelCase = "sneak_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
+local CamelCase = "snake_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
 --    ^            ^                          ^         ^
 ```
 <details><summary>Configuration</summary>
@@ -94,7 +94,7 @@ local neowords = require("neowords")
 local p = neowords.pattern_presets
 
 local hops = neowords.get_word_hops(
-  p.sneak_case,
+  p.snake_case,
   p.camel_case,
   p.upper_case,
   p.number,
@@ -116,7 +116,7 @@ vim.keymap.set({ "n", "x", "o" }, "ge", hops.backward_end)
 ### Numbers and hex color words
 ```lua
 -- Ignore anything except number and color words!
-local CamelCase = "99 sneak_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
+local CamelCase = "99 snake_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
 --                 ^                             ^
 local my_cool_color = "#E3B8EF"
 --                     ^

--- a/doc/neowords.nvim.txt
+++ b/doc/neowords.nvim.txt
@@ -38,7 +38,7 @@ SUB WORDS ONLY                       *neowords.nvim-show-cases-sub-words-only*
 
 >lua
     -- Ignore anything except sub words!
-    local CamelCase = "sneak_UPPER_MIXEDCase" .. "1234"
+    local CamelCase = "snake_UPPER_MIXEDCase" .. "1234"
     --    ^    ^       ^     ^     ^    ^         ^
 <
 
@@ -49,7 +49,7 @@ Configuration ~
     local p = neowords.pattern_presets
     
     local subword_hops = neowords.get_word_hops(
-      p.sneak_case,
+      p.snake_case,
       p.camel_case,
       p.upper_case,
       p.number,
@@ -69,7 +69,7 @@ BIG WORDS ONLY                       *neowords.nvim-show-cases-big-words-only*
 
 >lua
     -- Ignore anything except big words!
-    local CamelCase = "sneak_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
+    local CamelCase = "snake_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
     --    ^            ^                          ^         ^
 <
 
@@ -109,7 +109,7 @@ Configuration ~
     local p = neowords.pattern_presets
     
     local hops = neowords.get_word_hops(
-      p.sneak_case,
+      p.snake_case,
       p.camel_case,
       p.upper_case,
       p.number,
@@ -131,7 +131,7 @@ NUMBERS AND HEX COLOR WORDS*neowords.nvim-show-cases-numbers-and-hex-color-words
 
 >lua
     -- Ignore anything except number and color words!
-    local CamelCase = "99 sneak_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
+    local CamelCase = "99 snake_UPPER_MIXEDCase" .. "1234" .. "dashed-case"
     --                 ^                             ^
     local my_cool_color = "#E3B8EF"
     --                     ^

--- a/lua/neowords/init.lua
+++ b/lua/neowords/init.lua
@@ -2,7 +2,7 @@ local word_hops = require("neowords.word-hops")
 
 local M = {
   pattern_presets = {
-    sneak_case = "\\v[[:lower:]]+",
+    snake_case = "\\v[[:lower:]]+",
     camel_case = "\\v[[:upper:]][[:lower:]]+",
     upper_case = "\\v[[:upper:]]+[[:lower:]]@!",
     number = "\\v[[:digit:]]+",

--- a/tests/specs/corner-cases_spec.lua
+++ b/tests/specs/corner-cases_spec.lua
@@ -5,7 +5,7 @@ require("tests.custom-asserts").register()
 
 describe("corner-cases", function()
   it("hop forward_end from the middle of a word", function()
-    h.get_preset("several_sneak_words", { 1, 2 })()
+    h.get_preset("several_snake_words", { 1, 2 })()
     local hops = nw.get_word_hops("\\v[[:lower:]]+")
 
     h.perform_through_keymap(hops.forward_end, true)


### PR DESCRIPTION
The terminology should be snake_case

https://en.wikipedia.org/wiki/Snake_case

Never heard of sneak case and pretty sure that is not a thing. So this will help users who want to use your plugin by providing a more expected name. 